### PR TITLE
Support Device T1203

### DIFF
--- a/pkg/eufy_adapter.py
+++ b/pkg/eufy_adapter.py
@@ -63,7 +63,7 @@ class EufyAdapter(Adapter):
                 model = dev['type']
                 name = dev['name']
 
-                if model in ['T1201', 'T1202', 'T1211']:
+                if model in ['T1201', 'T1202', 'T1203', 'T1211']:
                     eufy_dev = lakeside.switch(address, code, model)
                     device = EufySwitch(self, _id, name, eufy_dev)
                 elif model in ['T1011', 'T1012', 'T1013']:


### PR DESCRIPTION
Support this device https://www.argos.co.uk/product/8635879 with model id T1203.  This is a Smartplug with power consumption monitoring, however only on/off is currently supported by the adapter.